### PR TITLE
Find the clax binary in the right place

### DIFF
--- a/install/clax_install.sh
+++ b/install/clax_install.sh
@@ -27,7 +27,7 @@ function create_dir {
 
 function copy_binary {
     echo "Copying clax binary to $dir"
-    cp $basedir/clax "$dir"
+    cp $basedir/../clax "$dir"
 }
 
 function create_ini {


### PR DESCRIPTION
The install script is inside "install" directory, but clax binary is outside, so we need the ".." to look for it.