### PR TITLE
README update stating ARMv7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ requests from stdin and write responses to stdout, which makes it suitable for i
 - Windows 2003, 2008, 2012
 - Solaris 10 i86pc
 - z/OS 390
+- Raspbian armv7
 
 ## Compiling, testing and installing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ requests from stdin and write responses to stdout, which makes it suitable for i
 - Windows 2003, 2008, 2012
 - Solaris 10 i86pc
 - z/OS 390
-- Raspbian armv7
+- Raspbian ARMv7
 
 ## Compiling, testing and installing
 


### PR DESCRIPTION
I've just tested Clax in Raspberry Pi 3 with Raspbian OS. It compiles, passes tests and works ok once you install xinetd, so I think docs should state that Clax is ARMv7 compatible:

**Testing from another machine**
`ktecho@DellPC$ curl -d 'command=uname -a' 192.168.1.137:11801/command
Linux raspberrypi 4.9.24-v7+ #993 SMP Wed Apr 26 18:01:23 BST 2017 armv7l GNU/Linux`

**Compile**
`pi@raspberrypi:~/clax $ make
OS= ARCH= WINDOWS= sh util/makeversion.sh
cc -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -MM clax_version.h popen2.c clax_dispatcher_tree.c clax.c clax_http.c clax_util.c clax_dispatcher_ping.c clax_dispatcher_command.c clax_dispatcher_index.c scandir.c clax_errors.c clax_dispatcher.c clax_platform.c clax_http_multipart.c clax_log.c clax_crc32.c clax_big_buf.c clax_command.c clax_options.c clax_ctx.c > .depend
make -C contrib/mbedtls -f Makefile.clax CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -D__STRING_CODE_SET__=\"ISO8859-1\""
make[1]: Entering directory '/home/pi/clax/contrib/mbedtls'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -D__STRING_CODE_SET__="ISO8859-1" ctr_drbg.c pk_wrap.c ecp_curves.c cipher_wrap.c pkcs12.c pkcs11.c error.c md5.c pkparse.c x509_csr.c ssl_cli.c gcm.c ecp.c blowfish.c ssl_ticket.c sha512.c timing.c md.c entropy_poll.c cipher.c version_features.c ripemd160.c rsa.c net.c entropy.c md_wrap.c sha256.c dhm.c pkwrite.c base64.c asn1parse.c ssl_tls.c pem.c version.c ssl_cache.c memory_buffer_alloc.c md2.c ecdsa.c ssl_srv.c x509_crt.c ecdh.c md4.c debug.c x509_create.c oid.c asn1write.c ssl_ciphersuites.c xtea.c aes.c x509write_crt.c arc4.c bignum.c aesni.c x509write_csr.c padlock.c threading.c x509_crl.c camellia.c x509.c certs.c pkcs5.c ssl_cookie.c havege.c ccm.c sha1.c hmac_drbg.c des.c pk.c platform.c  
make[1]: Leaving directory '/home/pi/clax/contrib/mbedtls'
make -C contrib/http-parser -f Makefile.clax CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -D__STRING_CODE_SET__=\"ISO8859-1\""
make[1]: Entering directory '/home/pi/clax/contrib/http-parser'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -D__STRING_CODE_SET__="ISO8859-1" http_parser.c  
make[1]: Leaving directory '/home/pi/clax/contrib/http-parser'
make -C contrib/multipart-parser-c -f Makefile.clax CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -D__STRING_CODE_SET__=\"ISO8859-1\""
make[1]: Entering directory '/home/pi/clax/contrib/multipart-parser-c'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall -D__STRING_CODE_SET__="ISO8859-1" multipart_parser.c  
make[1]: Leaving directory '/home/pi/clax/contrib/multipart-parser-c'
make -C contrib/inih CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall"
make[1]: Entering directory '/home/pi/clax/contrib/inih'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall ini.c  
make[1]: Leaving directory '/home/pi/clax/contrib/inih'
make -C contrib/base64 CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall"
make[1]: Entering directory '/home/pi/clax/contrib/base64'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall base64.c  
make[1]: Leaving directory '/home/pi/clax/contrib/base64'
make -C contrib/slre CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall"
make[1]: Entering directory '/home/pi/clax/contrib/slre'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall slre.c  
make[1]: Leaving directory '/home/pi/clax/contrib/slre'
make -C contrib/snprintf CC="cc" CFLAGS="-Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall"
make[1]: Entering directory '/home/pi/clax/contrib/snprintf'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall snprintf.c  
snprintf.c: In function 'vsnprintf':
make[1]: Leaving directory '/home/pi/clax/contrib/snprintf'
cc -c -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall popen2.c clax_dispatcher_tree.c clax.c clax_http.c clax_util.c clax_dispatcher_ping.c clax_dispatcher_command.c clax_dispatcher_index.c scandir.c clax_errors.c clax_dispatcher.c clax_platform.c clax_http_multipart.c clax_log.c clax_crc32.c clax_big_buf.c clax_command.c clax_options.c clax_ctx.c clax_util.h clax_log.h popen2.h 
cc -Icontrib -Icontrib/mbedtls -std=gnu99 -pedantic -Wall popen2.o clax_dispatcher_tree.o clax.o clax_http.o clax_util.o clax_dispatcher_ping.o clax_dispatcher_command.o clax_dispatcher_index.o scandir.o clax_errors.o clax_dispatcher.o clax_platform.o clax_http_multipart.o clax_log.o clax_crc32.o clax_big_buf.o clax_command.o clax_options.o clax_ctx.o  contrib/snprintf/snprintf.o contrib/inih/ini.o contrib/mbedtls/ssl_ticket.o contrib/mbedtls/gcm.o contrib/mbedtls/x509write_csr.o contrib/mbedtls/x509.o contrib/mbedtls/rsa.o contrib/mbedtls/md_wrap.o contrib/mbedtls/ecp_curves.o contrib/mbedtls/oid.o contrib/mbedtls/pkwrite.o contrib/mbedtls/ecdsa.o contrib/mbedtls/asn1parse.o contrib/mbedtls/padlock.o contrib/mbedtls/bignum.o contrib/mbedtls/memory_buffer_alloc.o contrib/mbedtls/md2.o contrib/mbedtls/ecdh.o contrib/mbedtls/x509_create.o contrib/mbedtls/timing.o contrib/mbedtls/asn1write.o contrib/mbedtls/pem.o contrib/mbedtls/md5.o contrib/mbedtls/x509write_crt.o contrib/mbedtls/arc4.o contrib/mbedtls/sha256.o contrib/mbedtls/camellia.o contrib/mbedtls/platform.o contrib/mbedtls/aes.o contrib/mbedtls/havege.o contrib/mbedtls/hmac_drbg.o contrib/mbedtls/error.o contrib/mbedtls/entropy.o contrib/mbedtls/sha512.o contrib/mbedtls/pkcs12.o contrib/mbedtls/ccm.o contrib/mbedtls/dhm.o contrib/mbedtls/x509_csr.o contrib/mbedtls/md4.o contrib/mbedtls/pk.o contrib/mbedtls/ssl_cache.o contrib/mbedtls/cipher.o contrib/mbedtls/version_features.o contrib/mbedtls/ssl_tls.o contrib/mbedtls/version.o contrib/mbedtls/ripemd160.o contrib/mbedtls/ssl_srv.o contrib/mbedtls/aesni.o contrib/mbedtls/x509_crt.o contrib/mbedtls/debug.o contrib/mbedtls/md.o contrib/mbedtls/pkcs5.o contrib/mbedtls/base64.o contrib/mbedtls/xtea.o contrib/mbedtls/entropy_poll.o contrib/mbedtls/threading.o contrib/mbedtls/x509_crl.o contrib/mbedtls/pkcs11.o contrib/mbedtls/ssl_ciphersuites.o contrib/mbedtls/pkparse.o contrib/mbedtls/ctr_drbg.o contrib/mbedtls/des.o contrib/mbedtls/pk_wrap.o contrib/mbedtls/cipher_wrap.o contrib/mbedtls/certs.o contrib/mbedtls/sha1.o contrib/mbedtls/ssl_cli.o contrib/mbedtls/net.o contrib/mbedtls/ssl_cookie.o contrib/mbedtls/ecp.o contrib/mbedtls/blowfish.o contrib/slre/slre.o contrib/http-parser/http_parser.o contrib/multipart-parser-c/multipart_parser.o contrib/base64/base64.o -o a.out
cp a.out clax
`
**Tests**
`pi@raspberrypi:~/clax $ make check-all  
[…]
make -C tests check
make[1]: Entering directory '/home/pi/clax/tests'
./test
# clax_big_buf
# clax_big_buf: default_values
ok 1
# clax_big_buf: creates_file_when_max_size
ok 2
# clax_big_buf: deletes_file_on_free
ok 3
# clax_big_buf: writes_memory_to_file
ok 4
# clax_big_buf: renames_file
ok 5
# clax_big_buf: read_from_memory
ok 6
# clax_big_buf: read_from_memory_more_than_available
ok 7
# clax_big_buf: read_from_file
ok 8
# clax_crc32
# clax_crc32: calculates crc32 from fd
ok 9
# clax_crc32: calculates crc32 from file
ok 10
# clax_command
# clax_command: start_runs_command
ok 11
# clax_command: start_returns_error
ok 12
# clax_command: read_reads_output
ok 13
# clax_command: runs_command_vaargs
ok 14
# clax_command: kills command after timeout
ok 15
# clax_command: clax_command_init_env - inits environment
ok 16
# clax_command: clax_command_set_env - sets new environment
ok 17
# clax_command: clax_command_set_env - overwrites environment
ok 18
# clax_command: clax_command_set_env_pair - sets environment from pair
ok 19
# clax_command: clax_command_get_env - correctly handles NULL environment
ok 20
# clax_command: clax_command_get_env - gets environment
ok 21
# clax_command: clax_command_env_expand_a - expands win environment
ok 22
# clax_command: clax_command_env_expand_a - expands unix environment
ok 23
# clax_command: clax_command_set_env - sets env with expansion
ok 24
# clax_command: kills command after timeout without any output
ok 25
# clax_dispatch
# clax_dispatch: sets_404_on_unknown_path
ok 26
# clax_dispatch: returns_bad_request_when_wrong_params
ok 27
# clax_dispatch: match_matches_paths
ok 28
# clax_dispatcher_index
# clax_dispatcher_index: returns info
ok 29
# clax_dispatcher_ping
# clax_dispatcher_ping: returns pong
ok 30
# clax_dispatcher_tree
# clax_dispatcher_tree: saves_upload_to_file
ok 31
# clax_dispatcher_tree: saves_upload_to_file_with_another_name
ok 32
# clax_dispatcher_tree: saves_upload_to_another_dir
ok 33
# clax_dispatcher_tree: rejects_upload_if_crc_fails
ok 34
# clax_dispatcher_tree: accepts_upload_with_correct_crc
ok 35
# clax_dispatcher_tree: accepts_upload_with_correct_crc padded
ok 36
# clax_dispatcher_tree: saves_upload_with_passed_time
ok 37
# clax_dispatcher_tree: creates directory
ok 38
# clax_dispatcher_tree: returns ok when file exists
ok 39
# clax_dispatcher_tree: returns ok when directory exists
ok 40
# clax_dispatcher_tree: serves_404_when_file_not_found
ok 41
# clax_dispatcher_tree: serves_file_as_attachment
ok 42
# clax_dispatcher_tree: serves file with crc32
ok 43
# clax_dispatcher_tree: serves file with padded crc32
ok 44
# clax_dispatcher_tree: deletes file
ok 45
# clax_dispatcher_tree: deletes directory
ok 46
# clax_dispatcher_tree: deletes directory recursively
path_info=/tree//tmp/clax.tmpdir.CrWHod
ok 47
# clax_dispatcher_tree: returns error when deleting unknown file
ok 48
# clax_dispatcher_command
# clax_dispatcher_command: returns_bad_request_when_wrong_params
ok 49
# clax_dispatcher_command: returns ok
ok 50
# clax_dispatcher_command: returns trailing headers
ok 51
# clax_dispatcher_command: returns trailing headers when timeout
ok 52
# clax_dispatcher_command: returns trailing headers when error
ok 53
# clax_http
# clax_http: parse_returns_error_when_error
ok 54
# clax_http: parse_returns_0_when_need_more
ok 55
# clax_http: parse_returns_ok_chunks
ok 56
# clax_http: parse_returns_done_when_100_continue
ok 57
# clax_http: parse_returns_ok
ok 58
# clax_http: parse_returns_error_when_path_has_zeros
ok 59
# clax_http: parse_saves_request
ok 60
# clax_http: parse_saves_body
ok 61
# clax_http: parse_parses_query_string
ok 62
# clax_http: parse_parses_form_body
ok 63
# clax_http: parse_parses_form_body_with_decoding
ok 64
# clax_http: parse_parses_multipart_body
ok 65
# clax_http: url_decode_decodes_string_inplace
ok 66
# clax_http: status_message_returns_message
ok 67
# clax_http: status_message_returns_unknown_message
ok 68
# clax_http: extract_kv_extracts_val
ok 69
# clax_http: chunked_writes_chunks
ok 70
# clax_http: write_response_writes
ok 71
# clax_http: check_basic_auth_checks_auth
ok 72
# clax_http_multipart_list
# clax_http_multipart_list: default_values
ok 73
# clax_http_multipart_list: pushes_multipart
ok 74
# clax_http_multipart_list: returns_item_at_position
ok 75
# clax_http_multipart_list: returns_last_item
ok 76
# clax_options
# clax_options: parses_config
ok 77
# clax_options: sanitizes paths
ok 78
# clax_options: overwrites values
ok 79
# clax_options: returns_error_when_config_not_found
ok 80
# clax_options: parses_log_file
ok 81
# clax_util
# clax_util: default_values
ok 82
# clax_util: pushes_kv
ok 83
# clax_util: pushes_buf_kv
ok 84
# clax_util: finds_all_kv
ok 85
# clax_util: finds_kv
ok 86
# clax_util: at_kv
ok 87
# clax_util: iter_kv
ok 88
# clax_util: sets_new_val
ok 89
# clax_util: clax_buf2str_allocates_str_from_buffer
ok 90
# clax_util: clax_buf_append_appends_buffer
ok 91
# clax_util: clax_strnapp_a - appends strings
ok 92
# clax_util: clax_san_path_fixes_path
ok 93
# clax_util: clax_strjoin_joins_strings
ok 94
# clax_util: htol converts hex to integer
ok 95
# clax_util: strdup duplicates a string
ok 96
# clax_util: strndup duplicates a string with max characters
ok 97
# clax_util: generates random string
ok 98
# clax_util: generates random string based on template
ok 99
# clax_util: generates random filename
ok 100
# clax_util: generates random filename with template
ok 101
# clax_util: slurps file
ok 102
# clax_util: appends new string
ok 103
# clax_util: appends empty string
ok 104
# clax_util: returns error when string does not fit
ok 105
# clax_util: contatenates file paths
ok 106
# clax_util: contatenates dir paths
ok 107
# clax_util: creates intermediate directories
ok 108
# clax_util: removes path recursively
ok 109
# clax_util: detects root if absolute
ok 110
1..110 (399)
SUCCESS
make[1]: Leaving directory '/home/pi/clax/tests'
make -C tests_func check
make[1]: Entering directory '/home/pi/clax/tests_func'
./test
# index
# index: index_page
ok 1
# index: ping
ok 2
# index: not found
ok 3
# index: method not allowed
ok 4
# basic_auth
# basic_auth: success
ok 5
# basic_auth: missing header
ok 6
# basic_auth: invalid header
ok 7
# basic_auth: invalid base64 in header
ok 8
# basic_auth: no colon
ok 9
# basic_auth: wrong username
ok 10
# basic_auth: wrong password
ok 11
# tree
# tree: upload
ok 12
# tree: upload_with_different_name
ok 13
# tree: download
ok 14
# tree: download_not_found
ok 15
# tree: delete file
ok 16
# tree: delete not found
ok 17
# command
# command: simple command
ok 18
# command: command failure
ok 19
# ssl
# ssl: rejects not ssl request
ok 20
1..20 (65)
SUCCESS
make[1]: Leaving directory '/home/pi/clax/tests_func'
`